### PR TITLE
スケジュール実行の時刻を変更

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -3,7 +3,7 @@ name: Link check CI
 
 on:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 22 * * *"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/posts-list.yml
+++ b/.github/workflows/posts-list.yml
@@ -3,7 +3,7 @@ name: Post list CI
 
 on:
   schedule:
-    - cron: "0 23 * * *"
+    - cron: "0 21 * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
# Issue
#10 

# 概要
再実行でコケた例がないのでタイミングの問題かもしれない。ということで試しに以下に変更して様子を見てみる。

6時にサイトマップチェック
7時にリンクチェック