### PR TITLE
broken-link-checkerをグローバルインストールに戻す

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -65,7 +65,7 @@ jobs:
               echo "Target {$url}"
               echo Getting links from "$url" >> $RESULT_FILE
               cat tmp.txt | grep 'BROKEN' >> $RESULT_FILE
-              cat tmp.txt | grep 'ERROR' >> $RESULT_FILE
+              cat tmp.txt | grep 'ERROR' --ignore-case >> $RESULT_FILE
               echo "-----------------------" >> $RESULT_FILE
               echo >> $RESULT_FILE
 

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -31,13 +31,13 @@ jobs:
 
       # 必要なパッケージのインストール
       - name: Install dependencies
-        run: npm ci
+        run: npm install broken-link-checker -g
 
       # 実行テスト
       # バージョンが変わったときのためにこの出力は残しておくか
       - name: Print version
         run: |
-          npx blc --version
+          blc --version
 
       # 結果ファイルやIssueに使う日付文字列の作成
       # https://stackoverflow.com/questions/60942067/get-current-date-and-time-in-github-workflows
@@ -59,7 +59,7 @@ jobs:
           echo >> $RESULT_FILE
           while read url
           do
-            npx blc -g --filter-level 0 "$url" > tmp.txt || {
+            blc -g --filter-level 0 "$url" > tmp.txt || {
               status=$?
               echo "Fail {$status}"
               echo "Target {$url}"


### PR DESCRIPTION
# Issue
#10 

# 概要
どうもエラーが出始めたのがローカルインストールに変更したタイミングに近い。ただそれだけで変わるものかは微妙だが、試しにグローバルインストールに戻してどうなるか切り分けも兼ねてやってみる。