### PR TITLE
同時リクエスト数を制限

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -59,7 +59,7 @@ jobs:
           echo >> $RESULT_FILE
           while read url
           do
-            npx blc -g --user-agent "Mozilla/5.0 (iPhone; CPU iPhone OS 14_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.1 Mobile/15E148 Safari/604.1" --filter-level 0 "$url" > tmp.txt || {
+            npx blc -g --requests 1 --user-agent "Mozilla/5.0 (iPhone; CPU iPhone OS 14_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.1 Mobile/15E148 Safari/604.1" --filter-level 0 "$url" > tmp.txt || {
               status=$?
               echo "Fail {$status}"
               echo "Target {$url}"


### PR DESCRIPTION
# Issue
#10 

# 概要
オプションとcli.jsの中身を見たところ同時リクエスト数が無制限状態だった。これが400エラーの原因かはなんともいえないが制限をかけて効果があるか検証してみる。

該当箇所
https://github.com/stevenvachon/broken-link-checker/blob/ce9e116590b63d23687f9eb403ab773e60f4fcf1/lib/cli.js#L569

`Infinity` になってるのでとりあえず1にしてみる。
https://github.com/stevenvachon/broken-link-checker/blob/427267fa87a458dc9f359daf5b1715d1a42803fe/lib/internal/defaultOptions.js#L18