### PR TITLE
内部リンクのチェックを除外

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -59,7 +59,7 @@ jobs:
           echo >> $RESULT_FILE
           while read url
           do
-            npx blc -g --requests 1 --user-agent "Mozilla/5.0 (iPhone; CPU iPhone OS 14_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.1 Mobile/15E148 Safari/604.1" --filter-level 0 "$url" > tmp.txt || {
+            npx blc -gi --requests 1 --user-agent "Mozilla/5.0 (iPhone; CPU iPhone OS 14_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.1 Mobile/15E148 Safari/604.1" --filter-level 0 "$url" > tmp.txt || {
               status=$?
               echo "Fail {$status}"
               echo "Target {$url}"


### PR DESCRIPTION
# Issue
#10 

# 概要
内部は全部静的ファイルなので基本的には見る必要なかった。
チェックしたいのは外部リンクのリンク切れなので除外する。