### PR TITLE
twitterの埋め込みリンクを一時除外

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -57,7 +57,7 @@ jobs:
           echo \# Link check result >> $RESULT_FILE
           while read url
           do
-            npx blc -gi --requests 1 --user-agent "Mozilla/5.0 (iPhone; CPU iPhone OS 14_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.1 Mobile/15E148 Safari/604.1" --filter-level 0 "$url" > tmp.txt || {
+            npx blc -gi --requests 1 --exclude 'twitter.com/tommy0157/status' --user-agent "Mozilla/5.0 (iPhone; CPU iPhone OS 14_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.1 Mobile/15E148 Safari/604.1" --filter-level 0 "$url" > tmp.txt || {
               status=$?
               echo "Fail {$status}"
               echo "Target {$url}"


### PR DESCRIPTION
# 概要
Twitter側の要因かもしれないが、今のところblcのオプションでは解消できそうにないので一旦チェック対象から外す。

# Issue
close Jpsern/jpsern.com#189