### PR TITLE
GitHub Docs のリンクを一時除外(再)

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -59,6 +59,7 @@ jobs:
           do
             npx blc -gi --requests 1 \
               --exclude 'twitter.com/tommy0157/status' \
+              --exclude 'docs.github.com' \
               --user-agent "Mozilla/5.0 (iPhone; CPU iPhone OS 14_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.1 Mobile/15E148 Safari/604.1" \
               --filter-level 0 "$url" > tmp.txt || {
               status=$?


### PR DESCRIPTION
# Issue
close #65 